### PR TITLE
Update v4 docs to use v4.0.1

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -18,7 +18,7 @@ If you generate a ColdBox application using any of our [elixir templates](https:
 {
   "private": true,
   "devDependencies": {
-    "coldbox-elixir": "^3.0.0"
+    "coldbox-elixir": "^4.0.1"
   }
 }
 ```


### PR DESCRIPTION
The v4 docs should reference coldbox-elixir v4, not v3.